### PR TITLE
Removing version from requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-SqlAlchemy==1.0.*
+SqlAlchemy

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py35,flake8
+envlist = py35,py27,flake8
 skip_missing_interpreters = true
 
 [flake8]


### PR DESCRIPTION
- The star in when installing `SQLAlchemy` is causing troubles in python 2.7.x; this change takes the client version already installed by the referencing projects.
- Adding `py27` as test env in tox file
- [ ] @albertein 
